### PR TITLE
feature: post-feed periodically updates

### DIFF
--- a/src/app/forum-explorer/components/forum-list/forum-list.component.spec.ts
+++ b/src/app/forum-explorer/components/forum-list/forum-list.component.spec.ts
@@ -73,7 +73,6 @@ describe('ForumListComponent', () => {
     fixture.destroy();
   }));
 
-  // TO DO
   it('should update the forums every 5 seconds', fakeAsync(() => {
     fixture.detectChanges();  // ngOnInit
     tick();                   // get forums from service


### PR DESCRIPTION
Previously the feed would only update by adding new user-created posts or when the forumId associated with the post list changed. Now the PostService is queried periodically (no more frequently than every 5 seconds) for an up-to-date list of posts.

closes #15 