### PR TITLE
feature: implement caching in the PostService

### DIFF
--- a/src/app/forum/services/forum.service.ts
+++ b/src/app/forum/services/forum.service.ts
@@ -59,7 +59,7 @@ export class ForumService {
     const values = Array.from(this.cache.values());
 
     // returns the cached forums only if there are forums in the cache
-    const $cachedForums = of(values.map(val => val[0]))
+    const cachedForums$ = of(values.map(val => val[0]))
       .pipe(
         filter(forums => forums.length !== 0));
 
@@ -71,12 +71,12 @@ export class ForumService {
       headers = headers.set('If-Modified-Since', oldestDate.toUTCString());
     }
 
-    const $serverResponse = this.http.get(
+    const serverResponse$ = this.http.get(
       `${environment.backendHost}/forums`,
       {headers, observe: 'response'});
 
     // If we are supplied newer forums, update the cache then return them
-    const $updatedForums = $serverResponse
+    const updatedForums$ = serverResponse$
       .pipe(
         filter(response => response.status === 200),
         tap(response => {
@@ -93,7 +93,7 @@ export class ForumService {
     plus the server not being able to provide us with a successful response, return
     an empty forum list.
      */
-    return concat($cachedForums, $updatedForums).pipe(defaultIfEmpty([]));
+    return concat(cachedForums$, updatedForums$).pipe(defaultIfEmpty([]));
   }
 
   /**
@@ -121,7 +121,7 @@ export class ForumService {
     const cachedValue = this.cache.get(id);
 
     // returns the cached forum if it exists
-    const $cachedForum = cachedValue ? of(cachedValue[0]) : EMPTY;
+    const cachedForum$ = cachedValue ? of(cachedValue[0]) : EMPTY;
 
     // if the cache contains a value for the given id, use the date to get the 'If-Modified-Since' header value
     let headers = new HttpHeaders();
@@ -130,12 +130,12 @@ export class ForumService {
       headers = headers.set('If-Modified-Since', date.toUTCString());
     }
 
-    const $serverResponse = this.http.get(
+    const serverResponse$ = this.http.get(
       `${environment.backendHost}/forums/${id}`,
       {headers, observe: 'response'});
 
     // If we are supplied a newer forum, update the cache then return it
-    const $updatedForum = $serverResponse
+    const updatedForum$ = serverResponse$
       .pipe(
         filter(response => response.status === 200),
         tap(response => {
@@ -151,7 +151,7 @@ export class ForumService {
     plus the server not being able to provide us with a successful response, return
     an empty forum list.
      */
-    return concat($cachedForum, $updatedForum).pipe(defaultIfEmpty(null));
+    return concat(cachedForum$, updatedForum$).pipe(defaultIfEmpty(null));
   }
 
   /**

--- a/src/app/forum/services/post.service.spec.ts
+++ b/src/app/forum/services/post.service.spec.ts
@@ -1,29 +1,77 @@
 import {PostService} from './post.service';
 import {Post} from '../models/post';
-import {HttpErrorResponse} from '@angular/common/http';
-import {fakeAsync} from '@angular/core/testing';
-import {asyncError, genericError} from '../../test_utils/test_async_utils';
+import {HttpHeaders, HttpResponse} from '@angular/common/http';
+import {fakeAsync, tick} from '@angular/core/testing';
+import {asyncData, asyncError, genericError} from '../../test_utils/test_async_utils';
 import {environment} from '../../../environments/environment';
-import {of} from 'rxjs';
+import {defer, EMPTY, of} from 'rxjs';
+
+function anHttpResponse(status: number, body?: any, headers?: HttpHeaders) {
+  return new HttpResponse({body, status, headers});
+}
 
 describe('PostService', () => {
   let service: PostService;
   let mockHttpClient;
-  const response404 = new HttpErrorResponse({error: 'test 404 error', status: 404, statusText: 'Not Found'});
-
 
   beforeEach(() => {
     mockHttpClient = jasmine.createSpyObj(['get', 'post']);
     service = new PostService(mockHttpClient);
   });
 
-
   it('should create', () => {
     expect(service).toBeTruthy();
   });
+});
 
+describe('PostService \'getPosts\' method', () => {
+  let service: PostService;
+  let mockHttpClient;
 
-  it('#getPosts should return empty list on error', fakeAsync(() => {
+  const exampleForumId = 3;
+  const examplePosts: Post[] = [
+    {
+      id: null,
+      forumId: exampleForumId,
+      title: 'post title',
+      body: 'post body'
+    },
+    {
+      id: null,
+      forumId: exampleForumId,
+      title: 'another post title',
+      body: 'another post body'
+    }
+  ];
+  beforeEach(() => {
+    mockHttpClient = jasmine.createSpyObj(['get']);
+    service = new PostService(mockHttpClient);
+  });
+
+  it('should make a valid get request', fakeAsync(() => {
+    // valid means to the correct URL with the 'If-Modified-Since' header if applicable
+
+    // if there is not cache yet, 'if-modified-since' header should NOT be in the request:
+    const creationDate: Date = new Date();
+    const headers: HttpHeaders = new HttpHeaders().set('Last-Modified', creationDate.toUTCString());
+    mockHttpClient.get.and.returnValue(asyncData(anHttpResponse(200, examplePosts, headers)));
+    service.getPosts(exampleForumId).subscribe();
+    tick(); // fills the cache as the server response above is emitted
+    expect(mockHttpClient.get).toHaveBeenCalledWith(
+      `${environment.backendHost}/posts?forumId=${exampleForumId}`,
+      {headers: jasmine.anything(), observe: 'response'});
+    mockHttpClient.get.calls.reset();
+
+    // if there is a cache, 'if-modified-since' header should be the oldest date in the cache
+    mockHttpClient.get.and.returnValue(EMPTY);
+    service.getPosts(exampleForumId);
+    const expectedHeaders = new HttpHeaders().set('If-Modified-Since', creationDate.toUTCString());
+    expect(mockHttpClient.get).toHaveBeenCalledWith(
+      `${environment.backendHost}/posts?forumId=${exampleForumId}`,
+      {headers: expectedHeaders, observe: 'response'});
+  }));
+
+  it('should return empty list on error', fakeAsync(() => {
     mockHttpClient.get.and.returnValue(
       asyncError(genericError)
     );
@@ -33,28 +81,149 @@ describe('PostService', () => {
       () => fail(' expected empty list on error, not error'));
   }));
 
-
-  it('#getPosts should return empty list on 404', fakeAsync(() => {
+  it('should return empty list on 404', fakeAsync(() => {
     mockHttpClient.get.and.returnValue(
-      asyncError(response404)
+      asyncData(anHttpResponse(404))
     );
-    // arbitrary choice of forumId
+    let emissions = 0;
     service.getPosts(1).subscribe(
-      posts => expect(posts).toEqual([]),
-      () => fail('expected empty list on 404, not error'));
+      posts => {
+        expect(posts).toEqual([]);
+        emissions++;
+      },
+      () => fail('expected empty list on 404, not error: '));
+    tick();
+    expect(emissions).toBe(1);
   }));
 
-
-  it('#getPosts should pass the forumId in the queryString', () => {
+  it('should pass the forumId in the queryString', () => {
     mockHttpClient.get.and.returnValue(
       of({}) // response doesn't matter
     );
     service.getPosts(666).subscribe();
-    expect(mockHttpClient.get).toHaveBeenCalledWith(`${environment.backendHost}/posts?forumId=666`);
+    expect(mockHttpClient.get).toHaveBeenCalledWith(`${environment.backendHost}/posts?forumId=666`, jasmine.anything());
   });
 
+  it('should return posts from server on first call where cache is empty', fakeAsync(() => {
+    mockHttpClient.get.and.returnValue(asyncData(anHttpResponse(200, examplePosts)));
+    let observableHasEmitted = false;
+    service.getPosts(exampleForumId).subscribe(posts => {
+        expect(posts).toEqual(examplePosts);
+        observableHasEmitted = true;
+      },
+      () => fail('should not error on trying to get posts'));
+    tick();
+    expect(observableHasEmitted).toBeTrue();
+  }));
 
-  it('#addPost should return the same post back on error', fakeAsync(() => {
+  it('should return cached value immediately (synchronously) on second call', fakeAsync(() => {
+    const testPosts: Post[] = [
+      {
+        id: 1,
+        forumId: exampleForumId,
+        title: 'post title',
+        body: 'post body'
+      },
+      {
+        id: 2,
+        forumId: exampleForumId,
+        title: 'another post title',
+        body: 'another post body'
+      }
+    ];
+    mockHttpClient.get.and.returnValue(asyncData(anHttpResponse(200, testPosts)));
+    // The first time we call we need to 'tick' as data is fetched from the server
+    service.getPosts(exampleForumId).subscribe();
+    tick();
+
+    // The second time an observable should be returned which emits a cached value immediately
+    // i.e. without calling tick() in the test here
+    let emitted = false;
+    service.getPosts(exampleForumId).subscribe(value => {
+      expect(value).toEqual(testPosts);
+      emitted = true;
+    });
+    expect(emitted).toBeTrue();
+  }));
+
+  it('should emit an updated value if it subsequently receives one after responding from cache', fakeAsync(() => {
+    mockHttpClient.get.and.returnValue(asyncData(anHttpResponse(200, examplePosts)));
+    // The first time we call we need to 'tick' as data is fetched from the server
+    service.getPosts(exampleForumId).subscribe();
+    tick();
+
+    // The second time an observable should be returned which emits a cached value immediately
+    // but will emit an updated value if it receives more up-to-date data
+    let valuesReceived = 0;
+    service.getPosts(exampleForumId).subscribe(() => valuesReceived++);
+    tick(); // for the server response
+    // received the initial value from cache and triggered again when updated data arrived
+    expect(valuesReceived).toBe(2);
+  }));
+
+  it('should not return a further value if it responded from the cache then received a 304', fakeAsync(() => {
+    const testPosts: Post[] = [
+      {
+        id: 1,
+        forumId: exampleForumId,
+        title: 'post title',
+        body: 'post body'
+      },
+      {
+        id: 2,
+        forumId: exampleForumId,
+        title: 'another post title',
+        body: 'another post body'
+      }
+    ];
+    mockHttpClient.get.and.returnValues(
+      asyncData(anHttpResponse(200, testPosts)),
+      asyncData(anHttpResponse(304)));
+    service.getPosts(exampleForumId).subscribe();
+    tick();
+    // exampleForums are now in the service's cache
+    let emissions = 0;
+    let returnedValue: Post[] = [];
+    service.getPosts(exampleForumId).subscribe(value => {
+      emissions++;
+      returnedValue = value;
+    });
+    // cache value should be return synchronously:
+    expect(emissions).toBe(1);
+    expect(returnedValue).toEqual(testPosts);
+
+    tick(); // server then responds 304
+    // but user already got value from cache so no further value should be emitted
+    expect(emissions).toBe(1);
+    expect(returnedValue).toEqual(testPosts);
+  }));
+});
+
+describe('PostService \'addPost\' method', () => {
+  let service: PostService;
+  let mockHttpClient;
+
+  const exampleForumId = 3;
+  const examplePost: Post = {
+    id: null,
+    forumId: exampleForumId,
+    title: 'post title',
+    body: 'post body'
+  };
+
+  beforeEach(() => {
+    mockHttpClient = jasmine.createSpyObj(['get', 'post']);
+    service = new PostService(mockHttpClient);
+  });
+
+  it('should make a valid request', () => {
+    // to the correct endpoint with the correct payload
+    mockHttpClient.post.and.returnValue(asyncData('any'));
+    service.addPost(examplePost);
+    expect(mockHttpClient.post).toHaveBeenCalledWith(`${environment.backendHost}/posts`, examplePost, jasmine.anything());
+  });
+
+  it('should return null on error', fakeAsync(() => {
     // The lack of an id in the returned post is an indication that an error occurred
     // this includes a 404 via HttpErrorResponse
     mockHttpClient.post.and.returnValue(
@@ -64,10 +233,9 @@ describe('PostService', () => {
     post.title = 'a title';
     post.body = 'some body text';
     service.addPost(post).subscribe(
-      value => expect(value).toEqual(post),
+      value => expect(value).toBeNull(),
       () => fail('expected a Post object, not an error'));
   }));
-
 
   it('should not try to add a post that already has an id', () => {
     const post = new Post();
@@ -75,4 +243,61 @@ describe('PostService', () => {
     expect(() => service.addPost(post)).toThrow();
     expect(mockHttpClient.post).toHaveBeenCalledTimes(0);
   });
+
+  it('should cache the response', fakeAsync(() => {
+    // server would assign an id
+    const postCopy = Object.assign({}, examplePost);
+    postCopy.id = 3;
+    mockHttpClient.post.and.returnValue(asyncData(anHttpResponse(201, postCopy)));
+    mockHttpClient.get.and.returnValue(defer(() => EMPTY));
+
+    service.addPost(examplePost).subscribe();
+    tick(); // HttpClient responds and cache should be updated
+
+    // As the new post should be in the cache now the following should pass
+    // synchronously with no need to 'tick'
+    let emissions = 0;
+    service.getPosts(exampleForumId).subscribe(
+      posts => {
+        expect(posts).toContain(postCopy);
+        emissions++;
+      },
+      () => fail()
+    );
+    expect(emissions).toBe(1);
+  }));
+
+  it('should return the new resource after successful creation and 201 received', fakeAsync(() => {
+    // the server should return the newly created forum in the response body
+
+    const newPostId = 1;
+    const returnedPost = Object.assign({id: newPostId}, examplePost);
+    mockHttpClient.post.and.returnValue(asyncData(anHttpResponse(201, returnedPost)));
+
+    let emissions = 0;
+    service.addPost(examplePost).subscribe(
+      post => {
+        expect(post).toEqual(returnedPost);
+        emissions++;
+      },
+      error => fail('should not error: ' + error.message)
+    );
+    tick(); // cache will be empty to tick to get server response
+    expect(emissions).toBe(1);
+  }));
+
+  it('should return null if server returns response other than 201', fakeAsync(() => {
+    mockHttpClient.post.and.returnValue(asyncData(new HttpResponse({status: 400})));
+
+    let emissions = 0;
+    service.addPost(examplePost).subscribe(
+      post => {
+        expect(post).toBeNull();
+        emissions++;
+      },
+      error => fail('should not error here: ' + error)
+    );
+    tick();
+    expect(emissions).toBe(1);
+  }));
 });

--- a/src/app/forum/services/post.service.ts
+++ b/src/app/forum/services/post.service.ts
@@ -1,11 +1,14 @@
 import {Injectable} from '@angular/core';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
-import {Observable, of} from 'rxjs';
+import {concat, EMPTY, Observable, of} from 'rxjs';
 import {Post} from '../models/post';
 import {environment} from '../../../environments/environment';
-import {catchError} from 'rxjs/operators';
+import {catchError, defaultIfEmpty, filter, map, pluck, tap} from 'rxjs/operators';
 
-const cudOptions = {headers: new HttpHeaders({'Content-Type': 'application/json'})};
+const cudOptions = {
+  headers: new HttpHeaders({'Content-Type': 'application/json'}),
+  observe: 'response' as 'response'
+};
 
 @Injectable({
   providedIn: 'root'
@@ -14,42 +17,101 @@ export class PostService {
 
   private baseURL: string = environment.backendHost;
   private postsEndpoint = '/posts';
+  private cache: Map<number, [Post, Date]> = new Map();
 
   constructor(private http: HttpClient) {
   }
 
+  /**
+   *  Returns a list of posts, maybe from the cache maybe from the server,
+   *  maybe from the cache then later from the server. The returned Observable
+   *  can make a maximum of two emissions.
+   *
+   *  There are four possible cases this method handles:
+   *
+   *              | server responds 200   | server responds non-200
+   *              | with new data         | and provides no data
+   *  ------------|---------------------------------------------------
+   *  cache empty | Cache updated         | [] returned on server
+   *              | New values returned   | response
+   *  ------------|---------------------------------------------------
+   *  cache active| Cache value returned  | Cache value returned
+   *              | initially ...         |
+   *              | Server value returned | Observable completes on
+   *              | when it arrives ...   | server response
+   *
+   * @param forumId the id of the forum for which posts are required
+   */
   getPosts(forumId: number): Observable<Post[]> {
-    return this.http.get<Post[]>(`${this.baseURL}${this.postsEndpoint}?forumId=${forumId}`)
-      .pipe(
-        catchError(this.handleError<Post[]>([]))
-      );
-  }
+    const relevantValues = Array.from(this.cache.values())
+      .filter(val => val[0].forumId === forumId);
+    const relevantPosts = relevantValues.map(val => val[0]);
+    const cachedPosts$ = of(relevantPosts).pipe(
+      filter(posts => posts.length !== 0)
+    );
 
-  addPost(post: Post): Observable<Post> {
-    /*
-      TODO - alter to conform with how a POST request would actually be responded
-
-      In reality a post request responds 201 and the location of the newly created resource
-     */
-    if (post.id) {
-      throw new Error('Post cannot already contain as this is assigned by the server.');
+    let headers = new HttpHeaders();
+    if (relevantValues.length > 0) {
+      const dates = relevantValues.map(pair => pair[1].getTime());
+      const oldestDate = new Date(Math.min(...dates));
+      headers = headers.set('If-Modified-Since', oldestDate.toUTCString());
     }
 
-    return this.http.post<Post>(`${this.baseURL}${this.postsEndpoint}`, post, cudOptions)
-      .pipe(
-        catchError(this.handleError<Post>(post))
-      );
+    const serverResponse$ = this.http.get(
+      `${this.baseURL}${this.postsEndpoint}?forumId=${forumId}`,
+      {headers, observe: 'response'}
+    );
+
+    const updatedPosts$ = serverResponse$.pipe(
+      catchError(() => EMPTY),
+      filter(response => response.status === 200),
+      tap(response => {
+        const newPosts = response.body as Post[];
+        const lastModified = new Date(response.headers.get('Last-Modified'));
+        relevantPosts.forEach(post => this.cache.delete(post.id));
+        newPosts.forEach(post => this.cache.set(post.id, [post, lastModified]));
+      }),
+      pluck('body'),
+    );
+
+    return concat(cachedPosts$, updatedPosts$).pipe(defaultIfEmpty([]));
   }
 
   /**
-   * Handle an error thrown by an observable and instead return an Observable
-   * of some default value.
+   * POSTs a new Post to be created on the server and then returns the newly
+   * created resource from the body of a 201 response.
    *
-   * TODO - introduce some logging service and log the error
+   * Returns null on a non-201 response.
    *
-   * @param defaultValue to return
+   * Throws an error if the newPost parameter has an id as ids can only be
+   * issued by the server
+   *
+   * If a newly created post is returned it is stored in the cache.
+   *
+   * @param newPost The new forum to be created on the server
    */
-  private handleError<T>(defaultValue?: T) {
-    return (error: any): Observable<T> => of(defaultValue as T);
+  addPost(newPost: Post): Observable<Post> {
+    if (newPost.id) {
+      throw new Error('Cannot add a forum that contains an ID: ID\'s are added by the server');
+    }
+
+    const postRequest$ = this.http.post<Post>(
+      `${environment.backendHost}/posts`,
+      newPost,
+      cudOptions);
+
+    // successful 201 responses result in returning the newly created form
+    // other responses elicit a return of null
+    return postRequest$.pipe(
+      map(response => {
+        if (response.status === 201) {
+          // on successful response, update the cache and return the value
+          this.cache.set(response.body.id, [response.body, new Date(0)]);
+          return response.body;
+        } else {
+          return null;
+        }
+      }),
+      catchError(() => of(null)));
   }
 }


### PR DESCRIPTION
PostService now caches responses, It will first respond from the cache initially if it has a cache for the request, then provide newer values if it receives some from the server later.

closes #18 