### PR TITLE
refactor: add router resolvers for navigation to forums

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -3,11 +3,27 @@ import {RouterModule, Routes} from '@angular/router';
 import {ForumComponent} from './forum/components/forum/forum.component';
 import {ForumExplorerComponent} from './forum-explorer/components/forum-explorer/forum-explorer.component';
 import {Error404Component} from './error-pages/error404/error404.component';
+import {ForumServiceCacheHeater} from './forum/services/forum-service-cache-heater.service';
+import {PostServiceCacheHeater} from './forum/services/post-service-cache-heater.service';
 
 
 const routes: Routes = [
   {path: '', redirectTo: 'forums', pathMatch: 'full'},
-  {path: 'forums/:id', component: ForumComponent},
+  {
+    path: 'forums/:id',
+    component: ForumComponent,
+    resolve: {
+      /**
+       * These resolvers no not work the way typical resolvers work.
+       * Their primary purpose is to ensure that the cache is hot in
+       * their respective services meaning that any component that uses
+       * them will get an immediate and synchronous response. This allows
+       * us to reuse these 'resolvers' in many places.
+       */
+      ForumServiceCacheHeater,
+      PostServiceCacheHeater
+    }
+  },
   {path: 'forums', component: ForumExplorerComponent},
   {path: 'page-not-found', component: Error404Component},
   {path: '**', redirectTo: 'page-not-found', pathMatch: 'full'}

--- a/src/app/forum/services/forum-service-cache-heater.service.spec.ts
+++ b/src/app/forum/services/forum-service-cache-heater.service.spec.ts
@@ -1,0 +1,40 @@
+import {TestBed} from '@angular/core/testing';
+
+import {ForumServiceCacheHeater} from './forum-service-cache-heater.service';
+import {ForumService} from './forum.service';
+import {ActivatedRouteSnapshot, Router} from '@angular/router';
+import {EMPTY, throwError} from 'rxjs';
+
+describe('ForumServiceCacheHeaterService', () => {
+  let service: ForumServiceCacheHeater;
+
+  const mockForumService = jasmine.createSpyObj(ForumService, ['getForum']);
+  const mockRouter = jasmine.createSpyObj(Router, ['navigateByUrl']);
+  const mockActivatedRouteSnapshot = {paramMap: {get: () => '3'}};
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: ForumService, useValue: mockForumService},
+        {provide: Router, useValue: mockRouter}
+      ]
+    });
+    service = TestBed.inject(ForumServiceCacheHeater);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should get the forum from the service', () => {
+    mockForumService.getForum.and.returnValue(EMPTY);
+    service.resolve(mockActivatedRouteSnapshot as unknown as ActivatedRouteSnapshot, null);
+    expect(mockForumService.getForum).toHaveBeenCalledWith(3);
+  });
+
+  it('should navigate to "/page-not-found" if the ForumService errors', () => {
+    mockForumService.getForum.and.returnValue(throwError('any'));
+    service.resolve(mockActivatedRouteSnapshot as unknown as ActivatedRouteSnapshot, null).subscribe();
+    expect(mockRouter.navigateByUrl).toHaveBeenCalledWith('/page-not-found', jasmine.anything());
+  });
+});

--- a/src/app/forum/services/forum-service-cache-heater.service.ts
+++ b/src/app/forum/services/forum-service-cache-heater.service.ts
@@ -1,0 +1,39 @@
+import {Injectable} from '@angular/core';
+import {ActivatedRouteSnapshot, Resolve, Router, RouterStateSnapshot} from '@angular/router';
+import {EMPTY, Observable} from 'rxjs';
+import {ForumService} from './forum.service';
+import {catchError, take} from 'rxjs/operators';
+import {Forum} from '../models/Forum';
+
+/**
+ * This resolver retrieves the forum with the id specified in the route.
+ *
+ * The resolver is used to ensure that the {@link ForumService} cache is hot
+ * so ignore the data field that it populates in the route. This often
+ * allows the same 'end goal' without adding any additional code to components
+ * that use the ForumService: if it can reply to a request from the cache it
+ * will do so synchronously.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class ForumServiceCacheHeater implements Resolve<Forum> {
+
+  constructor(
+    private forumService: ForumService,
+    private router: Router) {
+  }
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Forum> {
+    const id = parseInt(route.paramMap.get('id'), 10);
+
+    return this.forumService.getForum(id)
+      .pipe(
+        catchError(() => {
+          this.router.navigateByUrl('/page-not-found', {replaceUrl: true});
+          return EMPTY;
+        }),
+        take(1)
+      );
+  }
+}

--- a/src/app/forum/services/post-service-cache-heater.service.spec.ts
+++ b/src/app/forum/services/post-service-cache-heater.service.spec.ts
@@ -1,0 +1,32 @@
+import {TestBed} from '@angular/core/testing';
+
+import {PostServiceCacheHeater} from './post-service-cache-heater.service';
+import {ActivatedRouteSnapshot} from '@angular/router';
+import {PostService} from './post.service';
+import {EMPTY} from 'rxjs';
+
+describe('PostServiceCacheHeaterService', () => {
+  let service: PostServiceCacheHeater;
+
+  const mockPostService = jasmine.createSpyObj(PostService, ['getPosts']);
+  const mockActivatedRouteSnapshot = {paramMap: {get: () => '3'}};
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: PostService, useValue: mockPostService}
+      ]
+    });
+    service = TestBed.inject(PostServiceCacheHeater);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should get the posts from the service', () => {
+    mockPostService.getPosts.and.returnValue(EMPTY);
+    service.resolve(mockActivatedRouteSnapshot as unknown as ActivatedRouteSnapshot, null);
+    expect(mockPostService.getPosts).toHaveBeenCalledWith(3);
+  });
+});

--- a/src/app/forum/services/post-service-cache-heater.service.ts
+++ b/src/app/forum/services/post-service-cache-heater.service.ts
@@ -1,0 +1,31 @@
+import {Injectable} from '@angular/core';
+import {PostService} from './post.service';
+import {ActivatedRouteSnapshot, Resolve, RouterStateSnapshot} from '@angular/router';
+import {Post} from '../models/post';
+import {Observable} from 'rxjs';
+import {take} from 'rxjs/operators';
+
+/**
+ * This resolver retrieves the posts that belong to the forum with the id
+ * specified in the route.
+ *
+ * Although it can be used as per a standard resolver, another use is to
+ * use the resolver to ensure that the {@link PostService} cache is hot
+ * and ignore the data field that it populates in the route. This often
+ * allows the same 'end goal' without adding any additional code to components
+ * that use the PostService: if it can reply to a request from the cache it
+ * will do so synchronously.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class PostServiceCacheHeater implements Resolve<Post[]> {
+
+  constructor(private postService: PostService) {
+  }
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<Post[]> {
+    const forumId = parseInt(route.paramMap.get('id'), 10);
+    return this.postService.getPosts(forumId).pipe(take(1));
+  }
+}


### PR DESCRIPTION
Adds two router resolvers whose purpose is to heat up the cache in the ForumService and PostService. This means that subsequent requests to these services initially respond synchronously from the cache allowing the pre-loading effect of router resolvers without changing previously written code in the components that now benefit from it.

closes #14 