### PR TITLE
fix: various styling fixes

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -5,9 +5,11 @@
   </mat-sidenav>
 
   <mat-sidenav-content>
-    <span (click)="sidenav.toggle()" class="burger_menu">&#x2630;</span>
-    <h1 class="siteTitle"><b>S</b><span class="super-light">imple</span><b>F</b><span class="super-light">orum</span>
-    </h1>
+    <div class="titleBar">
+      <span (click)="sidenav.toggle()" class="burger_menu">&#x2630;</span>
+      <h1 class="siteTitle"><b>S</b><span class="super-light">imple</span><b>F</b><span class="super-light">orum</span>
+      </h1>
+    </div>
     <router-outlet (activate)="sidenav.close()"></router-outlet>
   </mat-sidenav-content>
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -11,12 +11,16 @@ span.burger_menu {
   }
 }
 
-.siteTitle {
-  display: inline;
-  padding-top: 0.5em;
-  padding-left: 0.5em;
+.titleBar {
+  margin-top: 0.5em;
 
-  .super-light {
-    font-weight: 100;
+  .siteTitle {
+    display: inline;
+    padding-top: 0.5em;
+    padding-left: 0.5em;
+
+    .super-light {
+      font-weight: 100;
+    }
   }
 }

--- a/src/app/authentication/login/login.component.scss
+++ b/src/app/authentication/login/login.component.scss
@@ -1,9 +1,9 @@
+@import "../mixins";
+
 div.container {
-  // center the container on the screen
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  /* the argument was chose as this value allows the appearance
+      of seamless transition between centering methods */
+  @include centerInWindow(465px);
 
   padding: 2em;
   box-sizing: border-box;

--- a/src/app/authentication/mixins.scss
+++ b/src/app/authentication/mixins.scss
@@ -1,0 +1,22 @@
+/*
+  Positions an element in the absolute center of the screen (both horizontally
+  and vertically) if the window height is above the given threshold
+
+  If the window height is below the given threshold, leave it in the normal
+  document flow but center is horizontally.
+ */
+@mixin centerInWindow($threshold) {
+  @media (max-height: $threshold) {
+    // center horizontally
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  @media(min-height: $threshold) {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+  }
+}
+

--- a/src/app/authentication/register/register.component.scss
+++ b/src/app/authentication/register/register.component.scss
@@ -1,9 +1,9 @@
+@import "../mixins";
+
 div.container {
-  // center the container on the screen
-  position: absolute;
-  left: 50%;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  /* the argument was chose as this value allows the appearance
+      of seamless transition between centering methods */
+  @include centerInWindow(672px);
 
   padding: 2em;
   box-sizing: border-box;

--- a/src/app/forum-explorer/components/forum-info/forum-info.component.html
+++ b/src/app/forum-explorer/components/forum-info/forum-info.component.html
@@ -2,8 +2,8 @@
   <mat-card>
     <mat-card-header>
       <mat-card-title class="name">{{forum?.name}}</mat-card-title>
+      <mat-card-subtitle class="creator">by: {{forum?.creator}}</mat-card-subtitle>
     </mat-card-header>
-    <mat-card-subtitle class="creator">{{forum?.creator}}</mat-card-subtitle>
     <mat-card-content>
       <p class="desc">{{forum?.description}}</p>
     </mat-card-content>

--- a/src/app/forum-explorer/components/forum-info/forum-info.component.scss
+++ b/src/app/forum-explorer/components/forum-info/forum-info.component.scss
@@ -10,11 +10,6 @@
     flex-basis: 400px;
     flex-grow: 1;
     margin: 0 0.5rem;
-
-    mat-card-subtitle {
-      float: right;
-      margin-bottom: 0;
-    }
   }
 
   button {

--- a/src/app/forum-explorer/components/forum-info/forum-info.component.spec.ts
+++ b/src/app/forum-explorer/components/forum-info/forum-info.component.spec.ts
@@ -69,7 +69,7 @@ describe('ForumInfoComponent', () => {
     fixture.detectChanges();
     const creatorDe: DebugElement = fixture.debugElement.query(By.css('.creator'));
     const creatorNe = creatorDe.nativeElement;
-    expect(creatorNe.textContent).toEqual(testForum.creator);
+    expect(creatorNe.textContent).toContain(testForum.creator);
   });
 
   it('should contain a button to the described forum', () => {

--- a/src/app/forum/components/post/post.component.html
+++ b/src/app/forum/components/post/post.component.html
@@ -1,8 +1,8 @@
 <mat-card>
   <mat-card-header>
     <mat-card-title class="title">{{post.title}}</mat-card-title>
+    <mat-card-subtitle class="creator">by: {{post.creator}}</mat-card-subtitle>
   </mat-card-header>
-  <mat-card-subtitle class="creator">{{post.creator}}</mat-card-subtitle>
   <mat-card-content>
     <p class="body">{{post.body}}</p>
   </mat-card-content>

--- a/src/app/forum/components/post/post.component.scss
+++ b/src/app/forum/components/post/post.component.scss
@@ -1,9 +1,4 @@
-mat-card-content {
+mat-card {
   text-align: left;
-}
-
-mat-card-subtitle {
-  float: right;
-  margin-bottom: 0;
 }
 

--- a/src/app/forum/components/post/post.component.spec.ts
+++ b/src/app/forum/components/post/post.component.spec.ts
@@ -42,7 +42,7 @@ describe('PostComponent', () => {
   it('should display the creator', () => {
     const creatorDe: DebugElement = fixture.debugElement.query(By.css('.creator'));
     const creatorNe = creatorDe.nativeElement;
-    expect(creatorNe.textContent).toBe(expectedPost.creator);
+    expect(creatorNe.textContent).toContain(expectedPost.creator);
   });
 
   it('should display the body', () => {


### PR DESCRIPTION
Previously the login and registration forms would overflow the top of the screen on most mobile landscape screens. This no longer happens.

A small margin was added to push the title of the site down slightly from the top of the window.

Closes #35 