### PR TITLE
fix: post body whitespace rendering

### DIFF
--- a/src/app/forum/components/post/post.component.scss
+++ b/src/app/forum/components/post/post.component.scss
@@ -2,3 +2,6 @@ mat-card {
   text-align: left;
 }
 
+p.body {
+  white-space: pre-wrap;
+}


### PR DESCRIPTION
whitespace was previously collapsed etc as is standard in html, now whitespace is preserved in post bodies only to allow for some basic formatting.